### PR TITLE
B-32 in mixer & check on`num_classes`

### DIFF
--- a/vit_jax/configs/models.py
+++ b/vit_jax/configs/models.py
@@ -295,6 +295,15 @@ def get_mixer_b16_config():
 
 
 @_register
+def get_mixer_b32_config():
+  """Returns Mixer-B/32 configuration."""
+  config = get_b16_config()
+  config.name = 'Mixer-B_32'
+  config.patches = ml_collections.ConfigDict({'size': (32, 32)})
+  return config
+
+
+@_register
 def get_mixer_l16_config():
   """Returns Mixer-L/16 configuration."""
   config = ml_collections.ConfigDict()

--- a/vit_jax/models_mixer.py
+++ b/vit_jax/models_mixer.py
@@ -64,5 +64,7 @@ class MlpMixer(nn.Module):
       x = MixerBlock(self.tokens_mlp_dim, self.channels_mlp_dim)(x)
     x = nn.LayerNorm(name='pre_head_layer_norm')(x)
     x = jnp.mean(x, axis=1)
-    return nn.Dense(self.num_classes, kernel_init=nn.initializers.zeros,
+    if self.num_classes:
+      x = nn.Dense(self.num_classes, kernel_init=nn.initializers.zeros,
                     name='head')(x)
+    return x

--- a/vit_jax/models_mixer.py
+++ b/vit_jax/models_mixer.py
@@ -66,5 +66,6 @@ class MlpMixer(nn.Module):
     x = jnp.mean(x, axis=1)
     if self.num_classes:
       x = nn.Dense(self.num_classes, kernel_init=nn.initializers.zeros,
-                    name='head')(x)
+                   name='head')(x)
     return x
+  


### PR DESCRIPTION
@andsteing, similarly to ViTs I am working on porting the Mixer models, and inside `gs://mixer-models` there are only six of them. One configuration that is missing is the Mixer-B_32. This PR adds that and also puts a check on `num_classes` so that the model instantiation is a bit more flexible.  