### PR TITLE
Implement GSAM for ICLR 2022 paper from Google Research

### DIFF
--- a/vit_jax/gsam.py
+++ b/vit_jax/gsam.py
@@ -1,0 +1,72 @@
+import jax
+import jax.numpy as jnp
+from vit_jax import utils
+
+def dual_vector(y, ):
+  """Returns the solution of max_x y^T x s.t. ||x||_2 <= 1.
+  Args:
+      y: A pytree of numpy ndarray, vector y in the equation above.
+      sign: -1.0 or 1.0
+  """
+  gradient_norm = jnp.sqrt(sum(
+        [jnp.sum(jnp.square(e)) for e in jax.tree_util.tree_leaves(y)]))
+  normalized_gradient = jax.tree_map(lambda x: x / gradient_norm, y)
+  return normalized_gradient, gradient_norm
+
+def gsam_gradient(loss_fn, base_opt, inputs, targets, grad_accum_steps,
+                  rho_max, rho_min, alpha, lr, lr_max, lr_min=0.0, eps=1e-12):
+  """
+  Get the GSAM gradient (https://openreview.net/pdf?id=edONMAnhLu-) of the loss function.
+  Args: 
+      loss_fn: the loss function.
+      base_opt: the base optimizer.
+      inputs: the inputs to the loss function.
+      targets: the targets to the loss function.
+      grad_accum_steps: the number of steps to accumulate the gradient.
+      rho_max: the maximum rho value for perturbation of weights.
+      rho_min: the minimum rho value for perturbation of weights.
+      alpha: the alpha value for the rho schedule, see Algorithm 1 in the paper.
+      lr: current learning rate.
+      lr_max: the maximum learning rate.
+      lr_min: the minimum learning rate.
+      eps: the epsilon value for numerical stability.
+
+  Returns:
+      l_clean: the loss function value.
+      g_gsam: the GSAM gradient. g_gsam is not averaged across workers, need to call "jax.lax.pmean" to average.
+  """
+  # Implementation considerations compared and summarized at
+  # https://docs.google.com/document/d/1g3kMEvqu1DOawaflKNyUsIoQ4yIVEoyE5ZlIPkIl4Lc/edit?hl=en#
+  l_clean, g_clean = utils.accumulate_gradient(jax.value_and_grad(loss_fn), base_opt.target,
+                                inputs, targets, grad_accum_steps)
+  g_clean_normalized, g_clean_length = dual_vector(g_clean)
+
+  if lr_max == lr_min:
+    sam_rho = rho_max
+  else:
+    sam_rho = rho_min + (rho_max - rho_min) * (lr - lr_min) / (lr_max - lr_min)
+    
+  # per-worker perturbation.
+  param_sam = jax.tree_multimap(lambda a, b: a + sam_rho * b / (g_clean_length + eps),
+                                base_opt.target, g_clean)
+
+  # get gradients at perturbed weights.
+  l_robust, g_robust = utils.accumulate_gradient(jax.value_and_grad(loss_fn), param_sam,
+                                inputs, targets, grad_accum_steps)
+
+  # decompose gradients.
+  g_clean_flatten, _ = jax.tree_flatten(g_clean)
+
+  g_robust_normalized, g_robust_length = dual_vector(g_robust)
+  g_robust_normalized_flatten, _ = jax.tree_flatten(g_robust_normalized)
+
+  g_clean_projection_norm = sum([jnp.vdot(p, q) for (p,q) in
+      zip(g_robust_normalized_flatten, g_clean_flatten)])
+  g_clean_residual = jax.tree_multimap(lambda a, b:
+      a - g_clean_projection_norm * b, g_clean,g_robust_normalized)
+
+  # get GSAM gradient.
+  g_gsam = jax.tree_multimap( lambda a, b: a - b * alpha, 
+      g_robust, g_clean_residual)
+      
+  return l_clean, g_gsam

--- a/vit_jax/train.py
+++ b/vit_jax/train.py
@@ -32,7 +32,7 @@ from vit_jax import input_pipeline
 from vit_jax import models
 from vit_jax import momentum_clip
 from vit_jax import utils
-
+from vit_jax.gsam import gsam_gradient
 
 def make_update_fn(*, apply_fn, accum_steps, lr_fn):
   """Returns update step for data parallel training."""
@@ -57,13 +57,19 @@ def make_update_fn(*, apply_fn, accum_steps, lr_fn):
           train=True)
       return cross_entropy_loss(logits=logits, labels=labels)
 
-    l, g = utils.accumulate_gradient(
-        jax.value_and_grad(loss_fn), opt.target, batch['image'], batch['label'],
-        accum_steps)
+    # get hyper-params for GSAM
+    RHO_MAX, RHO_MIN = config.get("rho_max", 0.5), config.get("rho_min", 0.1)
+    LR_MAX, LR_MIN = config.get("base_lr", 3e-3), config.get("min_lr", 3e-5)   
+    ALPHA = config.get("alpha", 0.05)
+    
+    learning_rate = lr_fn(step)
+    l, g = gsam_gradient(loss_fn=loss_fn, base_opt=opt, inputs=batch['image'], targets=batch['label'],
+        grad_accum_steps=accum_steps, rho_max=RHO_MAX, rho_min=RHO_MIN, alpha=ALPHA, lr=learning_rate, lr_max=LR_MAX, lr_min=LR_MIN)
+    
     g = jax.tree_map(lambda x: jax.lax.pmean(x, axis_name='batch'), g)
     l = jax.lax.pmean(l, axis_name='batch')
 
-    opt = opt.apply_gradient(g, learning_rate=lr_fn(step))
+    opt = opt.apply_gradient(g, learning_rate=learning_rate)
     return opt, l, new_rng
 
   return jax.pmap(update_fn, axis_name='batch', donate_argnums=(0,))


### PR DESCRIPTION
Hi, this is an implementation of the GSAM method in the [ICLR2022 paper](https://openreview.net/forum?id=edONMAnhLu-), which improves generalization by a large margin (e.g. +3.2% improvement over SAM in top-1 accuracy for ViT-B/32 on ImageNet-1k). 

SAM has been proved to improve generalization of ViT and MLP-Mixer in [another ICLR2022 paper](https://openreview.net/forum?id=LtKcMgGOeLt) whose checkpoints are already provided in this repository, GSAM further improves over SAM (typically >1% in ImageNet top-1 accuracy, the SAM baseline in Table 1 of [GSAM paper](https://openreview.net/forum?id=edONMAnhLu-) is a direct copy of Table2 in the [SAM paper](https://openreview.net/forum?id=LtKcMgGOeLt)).