### PR TITLE
Include reference to actual prompt source for CLIP

### DIFF
--- a/lit.ipynb
+++ b/lit.ipynb
@@ -437,7 +437,7 @@
         }
       ],
       "source": [
-        "# \"best prompts\" from CLIP paper (https://arxiv.org/abs/2103.00020)\n",
+        "# \"best prompts\" from CLIP paper (https://arxiv.org/abs/2103.00020), see https://github.com/openai/CLIP/blob/main/notebooks/Prompt_Engineering_for_ImageNet.ipynb\n",
         "PROMPTS = [\n",
         "    'itap of a {}.',\n",
         "    'a bad photo of the {}.',\n",


### PR DESCRIPTION
The linked CLIP paper doesn't mention these prompts at all, as far as I can tell the added GitHub reference is the only place they were made public. Not world-shattering, but was interesting enough for me to look up, maybe someone else can benefit from this too.