### PR TITLE
Fix checkpoint saving using wrong interval config

### DIFF
--- a/vit_jax/train.py
+++ b/vit_jax/train.py
@@ -34,6 +34,12 @@ from vit_jax import models
 from vit_jax import utils
 
 
+def _should_checkpoint(config, step, total_steps):
+  """Returns whether a checkpoint should be stored at the current step."""
+  return (step == total_steps or
+          bool(config.checkpoint_every and step % config.checkpoint_every == 0))
+
+
 def make_update_fn(*, apply_fn, accum_steps, tx):
   """Returns update step for data parallel training."""
 
@@ -239,8 +245,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
               img_sec_core_test=img_sec_core_test))
 
     # Store checkpoint.
-    if ((config.checkpoint_every and step % config.checkpoint_every == 0) or
-        step == total_steps):
+    if _should_checkpoint(config, step, total_steps):
       checkpoint_path = flax_checkpoints.save_checkpoint(
           workdir, (flax.jax_utils.unreplicate(params_repl),
                     flax.jax_utils.unreplicate(opt_state_repl), step), step)

--- a/vit_jax/train.py
+++ b/vit_jax/train.py
@@ -239,7 +239,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
               img_sec_core_test=img_sec_core_test))
 
     # Store checkpoint.
-    if ((config.checkpoint_every and step % config.eval_every == 0) or
+    if ((config.checkpoint_every and step % config.checkpoint_every == 0) or
         step == total_steps):
       checkpoint_path = flax_checkpoints.save_checkpoint(
           workdir, (flax.jax_utils.unreplicate(params_repl),

--- a/vit_jax/train_test.py
+++ b/vit_jax/train_test.py
@@ -37,6 +37,21 @@ JPG_BLACK_1PX = (b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\
 class TrainTest(parameterized.TestCase):
 
   @parameterized.named_parameters(
+      ('configured_interval', 6, 10, 3, True),
+      ('between_intervals', 4, 10, 3, False),
+      ('disabled', 4, 10, 0, False),
+      ('final_step_when_disabled', 10, 10, 0, True),
+  )
+  def test_should_checkpoint(self, step, total_steps, checkpoint_every,
+                             expected):
+    config = ml_collections.ConfigDict({
+        'checkpoint_every': checkpoint_every,
+        'eval_every': 2,
+    })
+    self.assertEqual(
+        train._should_checkpoint(config, step, total_steps), expected)
+
+  @parameterized.named_parameters(
       ('tfds', 'tfds'),
       ('directory', 'directory'),
   )


### PR DESCRIPTION
## Summary

The checkpoint saving condition checked config.checkpoint_every to determine whether checkpointing was enabled, but used config.eval_every for the modulo operation. That caused checkpoints to follow evaluation intervals instead of the configured checkpoint interval.

The fix now routes the decision through a small _should_checkpoint helper that consistently uses config.checkpoint_every. The final training step is still always checkpointed, including when periodic checkpointing is disabled.

## Regression coverage

The previous integration test used total_steps = 1, so it always exercised the final-step fallback and could not catch the interval mix-up. The new parameterized cases cover:

- a configured checkpoint interval
- a step between checkpoint intervals while eval_every is due
- disabled periodic checkpointing
- the final-step fallback when periodic checkpointing is disabled

## Verification

- Python compilation passed.
- Four focused regression cases passed on Python 3.10.
- The directory-backed end-to-end training case passed.
- The complete train_test module was attempted; its existing TFDS variant failed locally because the resolved tensorflow_datasets module lacks the expected builder API. That failure is unrelated to this change.

---
This change was prepared with AI assistance under human direction and review.