### PR TITLE
Restore nested empty checkpoint parameters

### DIFF
--- a/vit_jax/checkpoint.py
+++ b/vit_jax/checkpoint.py
@@ -61,7 +61,7 @@ def inspect_params(*,
   empty_keys = set()
   for k in missing_keys:
     if isinstance(expected_flat[k], dict) and not expected_flat[k]:
-      params[k] = {}
+      params_flat[k] = {}
       empty_keys.add(k)
   missing_keys -= empty_keys
 
@@ -77,7 +77,7 @@ def inspect_params(*,
                      f'Extra params in checkpoint: {extra_keys}.\n'
                      f'Restored params from checkpoint: {params_flat.keys()}.\n'
                      f'Expected params from code: {expected_flat.keys()}.')
-  return params
+  return recover_tree(params_flat.keys(), params_flat.values())
 
 
 def recover_tree(keys, values):

--- a/vit_jax/checkpoint_test.py
+++ b/vit_jax/checkpoint_test.py
@@ -15,6 +15,8 @@
 import tempfile
 
 from absl.testing import absltest
+from absl.testing import parameterized
+import flax
 import jax
 import jax.numpy as jnp
 
@@ -22,6 +24,51 @@ from vit_jax import checkpoint
 from vit_jax import models
 from vit_jax import test_utils
 from vit_jax.configs import models as config_lib
+
+
+class InspectParamsTest(parameterized.TestCase):
+
+  @parameterized.named_parameters(
+      ('top_level', {'empty': {}}),
+      ('nested', {'block': {'empty': {}}}),
+      ('deep', {'block': {'layer': {'empty': {}}}}),
+      ('siblings', {'block': {'first': {}, 'second': {}}}),
+  )
+  def test_restores_empty_subtrees(self, empty_subtrees):
+    kernel = jnp.array([1., 2.])
+    params = {'block': {'kernel': kernel}}
+    expected = {'block': {'kernel': kernel}}
+    for key, value in empty_subtrees.items():
+      if key == 'block':
+        expected['block'].update(value)
+      else:
+        expected[key] = value
+    result = checkpoint.inspect_params(params=params, expected=expected)
+    self.assertEqual(jax.tree.structure(result), jax.tree.structure(expected))
+    self.assertIs(result['block']['kernel'], kernel)
+    # The reconstructed tree must be usable as a Flax serialization state.
+    restored = flax.serialization.from_state_dict(expected, result)
+    self.assertEqual(jax.tree.structure(restored), jax.tree.structure(expected))
+
+  def test_rejects_missing_nonempty_parameters(self):
+    with self.assertRaisesRegex(ValueError, 'Missing params from checkpoint'):
+      checkpoint.inspect_params(
+          params={}, expected={'block': {'kernel': jnp.ones(2), 'empty': {}}})
+
+  def test_rejects_extra_parameters(self):
+    with self.assertRaisesRegex(ValueError, 'Extra params in checkpoint'):
+      checkpoint.inspect_params(
+          params={'unexpected': jnp.ones(2)}, expected={'block': {'empty': {}}})
+
+  def test_permissive_inspection_preserves_existing_parameters(self):
+    kernel = jnp.ones(2)
+    result = checkpoint.inspect_params(
+        params={'block': {'kernel': kernel}},
+        expected={'block': {'empty': {}}, 'missing': jnp.zeros(2)},
+        fail_if_extra=False, fail_if_missing=False)
+    self.assertEqual(set(result), {'block'})
+    self.assertEqual(set(result['block']), {'kernel', 'empty'})
+    self.assertIs(result['block']['kernel'], kernel)
 
 
 class CheckpointTest(absltest.TestCase):


### PR DESCRIPTION
`inspect_params` restores a missing nested empty subtree as a top-level key such as `block/empty`, leaving the checkpoint tree incompatible with the expected Flax structure.

Restore empty entries in the flattened parameter map, then rebuild the nested tree. Add coverage for nested and sibling empty subtrees, Flax deserialization, permissive inspection, and missing/extra parameter checks.

Validation: `python -m pytest -q vit_jax/checkpoint_test.py` passes all eight tests, including the existing pretrained checkpoint test. Four new regression cases fail on unchanged upstream. Syntax checks and `git diff --check` pass.
